### PR TITLE
Added php-gd for image manipulation

### DIFF
--- a/roles/php-on-apache/tasks/main.yml
+++ b/roles/php-on-apache/tasks/main.yml
@@ -8,6 +8,7 @@
     - php5-mcrypt
     - php5-intl
     - php5-curl
+    - php5-gd
 
 - name: enable php5-mcrypt
   sudo: true


### PR DESCRIPTION
Added the php-gd extension to the php-on-apache role. Required for image manipulation so that wordpress can create multiple image sizes for featured images.
